### PR TITLE
Relax Spring version requirement

### DIFF
--- a/spring-commands-standard.gemspec
+++ b/spring-commands-standard.gemspec
@@ -16,6 +16,6 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'spring', '>= 1.0', '< 3.0'
+  spec.add_dependency 'spring', '>= 1.0'
   spec.add_development_dependency 'rake'
 end


### PR DESCRIPTION
Related to #1.

Similar gems don't specify an upper limit for the Spring dependency.